### PR TITLE
Types: derive actions type from the symbiotes type

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 lib
 coverage
 .nyc_output
+types

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,7 +14,11 @@ export type Symbiotes<State> = {
   [Key in any]: Symbiote<State, any[]> | Symbiotes<State>;
 };
 
-export type Reducer<State> = (state: State, action: Action<any[]>) => State;
+interface BasicAction {
+  type: string | number | symbol;
+}
+
+export type Reducer<State> = (state: State, action: BasicAction) => State;
 
 export type ActionCreator<TSymbiote> = TSymbiote extends Symbiote<any, infer Arguments>
   ? (...payload: Arguments) => Action<Arguments>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,24 +1,26 @@
 // TypeScript Version: 2.8
 
+export {};
+
 export interface NamespaceOptions<State> {
-  namespace?: string
-  defaultReducer?: (prevState: State, action: Action) => State
-  separator?: string
+  namespace?: string;
+  defaultReducer?: (prevState: State, action: Action) => State;
+  separator?: string;
 }
 
-export type Symbiote<State> = (state: State, ...payload: any[]) => State
+export type Symbiote<State> = (state: State, ...payload: any[]) => State;
 
-export type Reducer<State> = (state: State, action: Action) => State
+export type Reducer<State> = (state: State, action: Action) => State;
 
 export type ActionsConfig<State, Actions> = {
   [Key in keyof Actions]: Actions[Key] extends Function // tslint:disable-line
     ? Symbiote<State>
     : ActionsConfig<State, Actions[Key]>
-}
+};
 
 export interface Action<Payload = any> {
-  type: string
-  payload?: Payload
+  type: string;
+  payload?: Payload;
 }
 
 export function createSymbiote<State, Actions>(
@@ -28,4 +30,4 @@ export function createSymbiote<State, Actions>(
 ): {
   actions: Actions
   reducer: Reducer<State>
-}
+};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,30 +4,52 @@ export {};
 
 export interface NamespaceOptions<State> {
   namespace?: string;
-  defaultReducer?: (prevState: State, action: Action) => State;
+  defaultReducer?: Reducer<State>;
   separator?: string;
 }
 
-export type Symbiote<State> = (state: State, ...payload: any[]) => State;
+// todo: Use just `export type Symbiote<State, Arguments extends any[]> = (state: State, ...payload: Arguments) => State;` when only TypeScript version 3+ is supported
+type Symbiote0<State> = (state: State) => State;
+type Symbiote1<State, A1> = (state: State, arg1: A1) => State;
+type Symbiote2<State, A1, A2> = (state: State, arg1: A1, arg2: A2) => State;
+type Symbiote3<State, A1, A2, A3> = (state: State, arg1: A1, arg2: A2, arg3: A3) => State;
+type Symbiote4<State, A1, A2, A3, A4> = (state: State, arg1: A1, arg2: A2, arg3: A3, arg4: A4, ...args: any[]) => State;
 
-export type Reducer<State> = (state: State, action: Action) => State;
+export type Reducer<State> = (state: State, action: Action<any[]>) => State;
 
-export type ActionsConfig<State, Actions> = {
-  [Key in keyof Actions]: Actions[Key] extends Function // tslint:disable-line
-    ? Symbiote<State>
-    : ActionsConfig<State, Actions[Key]>
+export type Symbiotes<State> = {
+  [Key in any]:
+    Symbiote0<State> |
+    Symbiote1<State, any> |
+    Symbiote2<State, any, any> |
+    Symbiote3<State, any, any, any> |
+    Symbiote4<State, any, any, any, any> |
+    Symbiotes<State>;
 };
 
-export interface Action<Payload = any> {
+export type ActionsCreators<TSymbiotes extends Symbiotes<any>> = {
+  [Key in keyof TSymbiotes]:
+    TSymbiotes[Key] extends Symbiote0<any> ? () => Action :
+    TSymbiotes[Key] extends Symbiote1<any, infer A1> ? (arg1: A1) => Action<[A1]> :
+    TSymbiotes[Key] extends Symbiote2<any, infer A1, infer A2> ? (arg1: A1, arg2: A2) => Action<[A1, A2]> :
+    TSymbiotes[Key] extends Symbiote3<any, infer A1, infer A2, infer A3> ? (arg1: A1, arg2: A2, arg3: A3) => Action<[A1, A2, A3]> :
+    TSymbiotes[Key] extends Symbiote4<any, infer A1, infer A2, infer A3, infer A4> ? (arg1: A1, arg2: A2, arg3: A3, arg4: A4, ...args: any[]) => Action<[A1, A2, A3, A4] & any[]> :
+    TSymbiotes[Key] extends Symbiotes<any> ? ActionsCreators<TSymbiotes[Key]> :
+    never
+};
+
+// todo: Replace [never] with [] when only TypeScript version 3+ is supported
+export interface Action<Payload extends any[] = [never]> {
   type: string;
-  payload?: Payload;
+  payload: Payload[0];
+  "symbiote-payload": Payload;
 }
 
-export function createSymbiote<State, Actions>(
+export function createSymbiote<State, TSymbiotes extends Symbiotes<State>>(
   initialState: State,
-  actionsConfig: ActionsConfig<State, Actions>,
+  actionsConfig: TSymbiotes,
   namespaceOptions?: string | NamespaceOptions<State>,
 ): {
-  actions: Actions
+  actions: ActionsCreators<TSymbiotes>
   reducer: Reducer<State>
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 export {};
 
@@ -8,38 +8,26 @@ export interface NamespaceOptions<State> {
   separator?: string;
 }
 
-// todo: Use just `export type Symbiote<State, Arguments extends any[]> = (state: State, ...payload: Arguments) => State;` when only TypeScript version 3+ is supported
-type Symbiote0<State> = (state: State) => State;
-type Symbiote1<State, A1> = (state: State, arg1: A1) => State;
-type Symbiote2<State, A1, A2> = (state: State, arg1: A1, arg2: A2) => State;
-type Symbiote3<State, A1, A2, A3> = (state: State, arg1: A1, arg2: A2, arg3: A3) => State;
-type Symbiote4<State, A1, A2, A3, A4> = (state: State, arg1: A1, arg2: A2, arg3: A3, arg4: A4, ...args: any[]) => State;
+export type Symbiote<State, Arguments extends any[]> = (state: State, ...payload: Arguments) => State;
+
+export type Symbiotes<State> = {
+  [Key in any]: Symbiote<State, any[]> | Symbiotes<State>;
+};
 
 export type Reducer<State> = (state: State, action: Action<any[]>) => State;
 
-export type Symbiotes<State> = {
-  [Key in any]:
-    Symbiote0<State> |
-    Symbiote1<State, any> |
-    Symbiote2<State, any, any> |
-    Symbiote3<State, any, any, any> |
-    Symbiote4<State, any, any, any, any> |
-    Symbiotes<State>;
-};
+export type ActionCreator<TSymbiote> = TSymbiote extends Symbiote<any, infer Arguments>
+  ? (...payload: Arguments) => Action<Arguments>
+  : never;
 
 export type ActionsCreators<TSymbiotes extends Symbiotes<any>> = {
   [Key in keyof TSymbiotes]:
-    TSymbiotes[Key] extends Symbiote0<any> ? () => Action :
-    TSymbiotes[Key] extends Symbiote1<any, infer A1> ? (arg1: A1) => Action<[A1]> :
-    TSymbiotes[Key] extends Symbiote2<any, infer A1, infer A2> ? (arg1: A1, arg2: A2) => Action<[A1, A2]> :
-    TSymbiotes[Key] extends Symbiote3<any, infer A1, infer A2, infer A3> ? (arg1: A1, arg2: A2, arg3: A3) => Action<[A1, A2, A3]> :
-    TSymbiotes[Key] extends Symbiote4<any, infer A1, infer A2, infer A3, infer A4> ? (arg1: A1, arg2: A2, arg3: A3, arg4: A4, ...args: any[]) => Action<[A1, A2, A3, A4] & any[]> :
+    TSymbiotes[Key] extends Symbiote<any, any[]> ? ActionCreator<TSymbiotes[Key]> :
     TSymbiotes[Key] extends Symbiotes<any> ? ActionsCreators<TSymbiotes[Key]> :
     never
 };
 
-// todo: Replace [never] with [] when only TypeScript version 3+ is supported
-export interface Action<Payload extends any[] = [never]> {
+export interface Action<Payload extends any[] = []> {
   type: string;
   payload: Payload[0];
   "symbiote-payload": Payload;

--- a/types/test.ts
+++ b/types/test.ts
@@ -25,8 +25,9 @@ interface PlainActionCreators {
 {
   // Works correct with plain state and actions
 
+  const initialState = { count: 0 };
   const { actions, reducer } = createSymbiote(
-    { count: 0 },
+    initialState,
     {
       inc: (state: PlainState) => ({ ...state, count: state.count + 1 }),
       dec: (state: PlainState) => ({ ...state, count: state.count + 1 }),
@@ -37,7 +38,8 @@ interface PlainActionCreators {
   reducer as Reducer<PlainState>;
 
   actions.inc();
-  actions.dec();
+  reducer(initialState, actions.dec());
+  reducer(initialState, { type: 'other' });
 }
 {
   // Throw error if the initial state type doesn't match the symbiotes state type

--- a/types/test.ts
+++ b/types/test.ts
@@ -63,16 +63,14 @@ interface PlainActionCreators {
 // symbiotes with arguments
 interface ArgumentedActionCreators {
   oneArg: (one: number) => Action<[number]>;
-  twoArgs: (one: string, two: number) => Action<[string, number]>;
-  threeArgs: (one: boolean, two: number, three: string) => Action<[boolean, number, string]>;
-  manyArgs: (one: '1', two: '2', three: '3', four: '4', five: '5', six: '6') => Action<['1', '2', '3', '4'] & any[]>;
+  oneOptionalArg: (one?: number) => Action<[number | undefined]>;
+  manyArgs: (one: number, two: boolean, three: string) => Action<[number, boolean, string]>;
 }
 
 const argumentedSymbiotes = {
   oneArg: (state: PlainState, one: number) => state,
-  twoArgs: (state: PlainState, one: string, two: number) => state,
-  threeArgs: (state: PlainState, one: boolean, two: number, three: string) => state,
-  manyArgs: (state: PlainState, one: '1', two: '2', three: '3', four: '4', five: '5', six: '6') => state,
+  oneOptionalArg: (state: PlainState, one?: number) => state,
+  manyArgs: (state: PlainState, one: number, two: boolean, three: string) => state,
 };
 
 {
@@ -86,7 +84,10 @@ const argumentedSymbiotes = {
   actions as ArgumentedActionCreators;
   reducer as Reducer<PlainState>;
 
-  actions.manyArgs('1', '2', '3', '4', '5', '6');
+  actions.oneArg(1);
+  actions.oneOptionalArg();
+  actions.oneOptionalArg(1);
+  actions.manyArgs(1, true, 'str');
 }
 {
   // Throw error if an action payload has an incorrect type
@@ -96,14 +97,9 @@ const argumentedSymbiotes = {
   actions.oneArg(); // $ExpectError
   actions.oneArg('wrong'); // $ExpectError
   actions.oneArg(1, 'excess'); // $ExpectError
-  actions.twoArgs('too few'); // $ExpectError
-  actions.twoArgs(1, 'wrong'); // $ExpectError
-  actions.twoArgs('right', 1, 'excess'); // $ExpectError
-  actions.threeArgs(true, 1); // $ExpectError
-  actions.threeArgs('wrong', 'wrong', true); // $ExpectError
-  actions.threeArgs(true, 1, 'right', 'excess'); // $ExpectError
-  actions.manyArgs('1', '2', '3'); // $ExpectError
-  actions.manyArgs('wrong', 1, 1, 1, 1, 1); // $ExpectError
+  actions.manyArgs(1, true); // $ExpectError
+  actions.manyArgs('wrong', 'wrong', true); // $ExpectError
+  actions.manyArgs(1, true, 'str', 'excess'); // $ExpectError
 }
 
 // nested symbiote

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,25 +1,25 @@
-import { createSymbiote } from "redux-symbiote"
+import { createSymbiote } from "redux-symbiote";
 
 // empty
-;(() => {
+{
   // Works correct with empty types
 
-  const { actions, reducer } = createSymbiote<{}, {}>({}, {})
-  actions // $ExpectType {}
-  reducer // $ExpectType Reducer<{}>
-})()
+  const { actions, reducer } = createSymbiote<{}, {}>({}, {});
+  actions; // $ExpectType {}
+  reducer; // $ExpectType Reducer<{}>
+}
 
 // plain symbiote
 interface PlainState {
-  count: number
+  count: number;
 }
 
 interface PlainActions {
-  inc: () => number
-  dec: () => number
+  inc: () => number;
+  dec: () => number;
 }
 
-;(() => {
+{
   // Works correct with plain state and actions
 
   const { actions, reducer } = createSymbiote<PlainState, PlainActions>(
@@ -28,38 +28,38 @@ interface PlainActions {
       inc: (state: PlainState) => ({ ...state, count: state.count + 1 }),
       dec: (state: PlainState) => ({ ...state, count: state.count + 1 }),
     },
-  )
+  );
 
-  actions // $ExpectType PlainActions
-  reducer // $ExpectType Reducer<PlainState>
-})()
-;(() => {
+  actions; // $ExpectType PlainActions
+  reducer; // $ExpectType Reducer<PlainState>
+}
+{
   // Throw error if actions config have a incorrect type
 
   const symbiotes = {
     inc: (state: PlainState) => ({ ...state, count: "hello!" }),
     dec: (state: PlainState) => ({ ...state, count: state.count - 1 }),
-  }
+  };
 
-  createSymbiote<PlainState, PlainActions>({ count: 0 }, symbiotes) // $ExpectError
-})()
-;(() => {
+  createSymbiote<PlainState, PlainActions>({ count: 0 }, symbiotes); // $ExpectError
+}
+{
   // Throw error if initial state have a incorrect type
 
   const symbiotes = {
     inc: (state: PlainState) => ({ ...state, count: state.count + 1 }),
     dec: (state: PlainState) => ({ ...state, count: state.count + 1 }),
-  }
+  };
 
-  createSymbiote<PlainState, PlainActions>({ count: "hello!" }, symbiotes) // $ExpectError
-})()
+  createSymbiote<PlainState, PlainActions>({ count: "hello!" }, symbiotes); // $ExpectError
+}
 
 // symbiote with arguments
 interface ArgumentedActions {
-  change: (diff: number) => number
+  change: (diff: number) => number;
 }
 
-;(() => {
+{
   // Works correct with plain state and actions with argument
 
   const { actions, reducer } = createSymbiote<PlainState, ArgumentedActions>(
@@ -70,12 +70,12 @@ interface ArgumentedActions {
         count: state.count + diff,
       }),
     },
-  )
+  );
 
-  actions // $ExpectType ArgumentedActions
-  reducer // $ExpectType Reducer<PlainState>
-})()
-;(() => {
+  actions; // $ExpectType ArgumentedActions
+  reducer; // $ExpectType Reducer<PlainState>
+}
+{
   // Throw error if action payload have a incorrect type
 
   // TODO: Must throw error!
@@ -85,25 +85,25 @@ interface ArgumentedActions {
       ...state,
       count: state.count + parseInt(diff, 10),
     }),
-  }
+  };
 
-  createSymbiote<PlainState, ArgumentedActions>({ count: 0 }, symbiote)
-})()
+  createSymbiote<PlainState, ArgumentedActions>({ count: 0 }, symbiote);
+}
 
 // nested symbiote
 interface NestedState {
   counter: {
     count: number
-  }
+  };
 }
 
 interface NestedActions {
   counter: {
     inc: () => number
-  }
+  };
 }
 
-;(() => {
+{
   // Works correct with nested state and actions
 
   const { actions, reducer } = createSymbiote<NestedState, NestedActions>(
@@ -116,12 +116,12 @@ interface NestedActions {
         }),
       },
     },
-  )
+  );
 
-  actions // $ExpectType NestedActions
-  reducer // $ExpectType Reducer<NestedState>
-})()
-;(() => {
+  actions; // $ExpectType NestedActions
+  reducer; // $ExpectType Reducer<NestedState>
+}
+{
   // Throws error if nested state have an incorrect type
 
   const symbiote = {
@@ -131,17 +131,17 @@ interface NestedActions {
         counter: { ...state.counter, count: state.counter.count + 1 },
       }),
     },
-  }
+  };
 
   const { actions, reducer } = createSymbiote<NestedState, NestedActions>(
-    { counter: { cnt: 0 } },
+    { counter: { cnt: 0 } }, // $ExpectError
     symbiote,
-  ) // $ExpectError
+  );
 
-  actions // $ExpectType NestedActions
-  reducer // $ExpectType Reducer<NestedState>
-})()
-;(() => {
+  actions; // $ExpectType NestedActions
+  reducer; // $ExpectType Reducer<NestedState>
+}
+{
   // Throws error if nested action have an incorrect type
 
   const symbiote = {
@@ -151,13 +151,13 @@ interface NestedActions {
         counter: { ...state.counter, count: "newString" },
       }),
     },
-  }
+  };
 
   const { actions, reducer } = createSymbiote<NestedState, NestedActions>(
     { counter: { count: 0 } },
-    symbiote,
-  ) // $ExpectError
+    symbiote, // $ExpectError
+  );
 
-  actions // $ExpectType NestedActions
-  reducer // $ExpectType Reducer<NestedState>
-})()
+  actions; // $ExpectType NestedActions
+  reducer; // $ExpectType Reducer<NestedState>
+}

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -2,6 +2,6 @@
   "extends": "dtslint/dtslint.json",
   "rules": {
     "semicolon": [true, "always"],
-    "indent": [true, "tabs"]
+    "indent": [true, "spaces", 2]
   }
 }


### PR DESCRIPTION
Resolves #28 

Sorry for the long delay, I was quite busy.

Now one doesn't need to write the action types, TypeScript does it automatically:

```ts
interface State {
  value: string;
}

const symbiotes = {
  foo(state: State) {
    return {...state, value: 'foo'};
  },
  bar(state: State, value: number) {
    return {...state, value: `bar ${value}`};
  }
};

const {actions, reducer} = createSymbiote({value: 'Hi'}, symbiotes);

actions.bar('cocktail'); // TS error, a number is expected
reducer({ value: 42 }, actions.foo()); // TS error, the value property must be a string
reducer({ value: 'Hi!' }, actions.bar(12)); // TS: 👍
```

I failed to implement the symbiotes optional arguments support in TypeScript 2.8 so I had to set the minimal TypeScript version to 3.0 in daacb4353de367bf1e961fbf43480706c86fe686. Also this upgrade has allowed to implement a more simple and robust solution. I think this change is not critical because the version 3.0 is only 2 month younger than 2.8 and migrating from TypeScript 2 to 3 is not a big deal.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#28: Types: derive actions type from the symbiotes type](https://issuehunt.io/repos/121889911/issues/28)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->