### PR TITLE
Close #27. Nanoid/non-secure for old ie

### DIFF
--- a/src/nanoid.js
+++ b/src/nanoid.js
@@ -1,11 +1,22 @@
-/* eslint-disable global-require */
-if (typeof document !== "undefined") {
+/* eslint-disable global-require, no-restricted-globals */
+let globalSelf = null
+
+if (typeof window !== "undefined") {
+  globalSelf = window
+} else if (typeof global !== "undefined") {
+  globalSelf = global
+} else if (typeof self !== "undefined") {
+  globalSelf = self
+}
+
+const document = globalSelf && globalSelf.document
+const crypto = globalSelf && (globalSelf.crypto || globalSelf.msCrypto)
+const navigator = globalSelf && globalSelf.navigator
+
+if (document && crypto) {
   // web
   module.exports = require("nanoid")
-} else if (
-  typeof navigator !== "undefined" &&
-  navigator.product === "ReactNative"
-) {
+} else if (navigator && navigator.product === "ReactNative") {
   // react native
   module.exports = require("nanoid/non-secure")
 } else {

--- a/test/nanoid-node.js
+++ b/test/nanoid-node.js
@@ -1,0 +1,8 @@
+import test from "ava"
+
+const expected = require("nanoid/non-secure")
+const imported = require("../src/nanoid")
+
+test("should load non-secure nanoid", (t) => {
+  t.true(expected === imported)
+})

--- a/test/nanoid-web.js
+++ b/test/nanoid-web.js
@@ -1,6 +1,7 @@
 import test from "ava"
 
 global.document = {}
+global.crypto = {}
 
 const expected = require("nanoid")
 const imported = require("../src/nanoid")


### PR DESCRIPTION
closes https://github.com/sergeysova/redux-symbiote/issues/27
```js
import { createStore } from 'redux'
import { createSymbiote } from "redux-symbiote";

const initialState = 0;

const symbiotes = {
  INCREMENT: state => state + 1,
  DECREMENT: state => state - 1
};

const { actions, reducer } = createSymbiote(
  initialState,
  symbiotes
);

const store = createStore(reducer);

console.log(`Should be 0: ${store.getState()}`)
store.dispatch(actions.INCREMENT())
store.dispatch(actions.INCREMENT())
store.dispatch(actions.INCREMENT())
store.dispatch(actions.DECREMENT())
console.log(`Should be 2: ${store.getState()}`)

console.log(store, actions)
```
![Скриншот 2019-11-06 21 11 49](https://user-images.githubusercontent.com/6834243/68325356-404ed480-00da-11ea-8be6-cbdf555137df.png)